### PR TITLE
Update to how tests are run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ notifications:
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always
 
-script: nosetests tests/tests.py -v
+script: nosetests -c nose.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ notifications:
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always
 
-script: cd tests/ && python tests.py -v
+script: nosetests tests/tests.py -v

--- a/nose.cfg
+++ b/nose.cfg
@@ -1,0 +1,3 @@
+[nosetests]
+verbosity=3
+exe=True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.13.0
 mock==2.0.0
+nose==1.3.7


### PR DESCRIPTION
Update for fix #53 
The previous way was a bit tacky as it runs only that single test. By setting up a configuration, all specifications for running tests are set there and this way it runs all tests found.